### PR TITLE
chore(ci): consolidate GitHub Actions dependency updates

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,11 +17,11 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
       - run: uv run --only-group docs zensical build --clean
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site
       - uses: actions/deploy-pages@v4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -53,7 +53,7 @@ jobs:
         run: uv build
 
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: python-package-distributions
           path: dist/
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/
@@ -90,12 +90,12 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v3.1.0
+        uses: sigstore/gh-action-sigstore-python@v3.3.0
         with:
           inputs: >-
             ./dist/*.tar.gz


### PR DESCRIPTION
## Summary
- Consolidate five Dependabot workflow update PRs into a single CI/docs workflow maintenance change.
- Update workflow actions in `.github/workflows/main.yaml`: `actions/upload-artifact` to `v7`, `actions/download-artifact` to `v8`, and `sigstore/gh-action-sigstore-python` to `v3.3.0`.
- Update workflow actions in `.github/workflows/docs.yaml`: `actions/configure-pages` to `v6` and `actions/upload-pages-artifact` to `v5`.

## Why
- Keep GitHub Actions dependencies current while reducing PR noise and review overhead.
- Apply related workflow version bumps together so CI and docs pipeline updates are reviewed as one cohesive change.